### PR TITLE
Use simple_logger in example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ libsystemd = "0.5.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
-env_logger = "0.9.0"
 serde_json = "1.0.86"
 rand = "0.8.5"
 log = { version = "0.4.1", features = ["kv_unstable_std"] }


### PR DESCRIPTION
env_logger 0.10.0 has higher MSRV than we'd like to support and thus breaks our examples in CI.