### PR TITLE
Create fork support older glibc versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Run [`cargo-release`][cr] to publish a release.
 - `JournalLog` no longer panics when sending a log record to journald fails; instead it silently discards the error.
 - `current_exe_identifier` now returns `Option` instead of `Result`.
 - Bump MSRV to `1.71.0`.
+- (Only in the fork systemd-journal-logger-memfd-sycall): use `memfd_crate` syscall instead of libc function.
 
 ### Removed
 - `JournalLog::default`, since instantiation is now fallible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "systemd-journal-logger"
+name = "systemd-journal-logger-memfd-syscall"
 version = "2.0.0"
-authors = ["Sebastian Wiesner <sebastian@swsnr.de>"]
+authors = ["Sebastian Wiesner <sebastian@swsnr.de>", "Daniel Estevez <daniel@destevez.net>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/swsnr/systemd-journal-logger.rs"
-documentation = "https://docs.rs/systemd-journal-logger"
-description = "Systemd journal logger for the log facade."
+repository = "https://github.com/daniestevez/systemd-journal-logger.rs"
+documentation = "https://docs.rs/systemd-journal-logger-memfd-syscall"
+description = "Systemd journal logger for the log facade (fork supporting older glibc versions)"
 categories = ["development-tools::debugging"]
 keywords = ["logging", "systemd", "journal"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,39 @@
-# systemd-journal-logger
+# systemd-journal-logger-memfd-syscall
 
-A pure Rust [log] logger for the [systemd journal][1].
+A pure Rust [log] logger for the [systemd journal][1] (fork supporting older glibc versions).
 
 [log]: https://docs.rs/log
 [1]: https://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
 
+## About this fork
+
+This crate is a fork of
+[systemd-journal-logger](https://github.com/swsnr/systemd-journal-logger.rs). The
+only reason for the existence of this fork is that the maintainer of
+`systemd-journal-logger`
+[is not willing to support glibc versions older than 2.27](https://github.com/swsnr/systemd-journal-logger.rs/issues/22).
+
+The
+[only modification included in this fork](https://github.com/daniestevez/systemd-journal-logger.rs/commit/60700e9d911346f613137b63704811268f8807e1)
+is calling the `memfd_create`
+syscall (which is available starting with the Linux kernel 3.17) instead of the
+`memfd_create()` libc function, which in glibc it is available starting with
+glibc 2.27, while Rust supports glibc >= 2.17.
+
+This fork will try to merge all the changes done upstream and release versions
+in the same way as upstream.
+
 ## Usage
 
 ```console
-$ cargo add systemd-journal-logger
+$ cargo add systemd-journal-logger-memfd-syscall
 ```
 
 Then initialize the logger at the start of `main`:
 
 ```rust
 use log::{info, warn, error, LevelFilter};
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 JournalLog::new().unwrap().install().unwrap();
 log::set_max_level(LevelFilter::Info);
@@ -29,7 +47,7 @@ You can also add additional fields to every log message, such as the version of 
 
 ```rust
 use log::{info, warn, error, LevelFilter};
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 JournalLog::new()
     .unwrap()

--- a/examples/systemd_service.rs
+++ b/examples/systemd_service.rs
@@ -25,7 +25,7 @@
 
 use log::{info, LevelFilter, Log};
 use std::io::prelude::*;
-use systemd_journal_logger::{connected_to_journal, JournalLog};
+use systemd_journal_logger_memfd_syscall::{connected_to_journal, JournalLog};
 
 struct SimpleLogger;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! ```rust
 //! use log::{info, warn, error, LevelFilter};
-//! use systemd_journal_logger::JournalLog;
+//! use systemd_journal_logger_memfd_syscall::JournalLog;
 //!
 //! JournalLog::new().unwrap().install().unwrap();
 //! log::set_max_level(LevelFilter::Info);
@@ -43,7 +43,7 @@
 //!
 //! ```rust
 //! use log::{info, warn, error, LevelFilter};
-//! use systemd_journal_logger::JournalLog;
+//! use systemd_journal_logger_memfd_syscall::JournalLog;
 //!
 //! JournalLog::new()
 //!     .unwrap()

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -13,7 +13,7 @@ use log::info;
 mod journal;
 
 use similar_asserts::assert_eq;
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 #[test]
 fn init() {

--- a/tests/init_with_extra_fields.rs
+++ b/tests/init_with_extra_fields.rs
@@ -13,7 +13,7 @@ use log::info;
 mod journal;
 
 use similar_asserts::assert_eq;
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 #[test]
 fn init_with_extra_fields() {

--- a/tests/journal_stream.rs
+++ b/tests/journal_stream.rs
@@ -36,7 +36,7 @@ fn main() {
 
     match std::env::var(env_name) {
         Ok(target) => {
-            use systemd_journal_logger::*;
+            use systemd_journal_logger_memfd_syscall::*;
 
             JournalLog::new().unwrap().install().unwrap();
             log::set_max_level(LevelFilter::Debug);

--- a/tests/log_to_journal.rs
+++ b/tests/log_to_journal.rs
@@ -15,7 +15,7 @@ use log::kv::Value;
 use log::{Level, Log, Record};
 use similar_asserts::assert_eq;
 
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 mod journal;
 
@@ -28,7 +28,7 @@ fn simple_log_entry() {
             .module_path(Some(module_path!()))
             .file(Some(file!()))
             .line(Some(92749))
-            .args(format_args!("systemd_journal_logger test: {}", 42))
+            .args(format_args!("systemd_journal_logger_memfd_syscall test: {}", 42))
             .build(),
     );
 
@@ -36,7 +36,7 @@ fn simple_log_entry() {
 
     assert_eq!(entry["TARGET"], "simple_log_entry");
     assert_eq!(entry["PRIORITY"], "4");
-    assert_eq!(entry["MESSAGE"], "systemd_journal_logger test: 42");
+    assert_eq!(entry["MESSAGE"], "systemd_journal_logger_memfd_syscall test: 42");
     assert_eq!(entry["CODE_FILE"], file!());
     assert_eq!(entry["CODE_LINE"], "92749");
     assert_eq!(entry["CODE_MODULE"], module_path!());
@@ -65,7 +65,7 @@ fn internal_null_byte_in_message() {
         &Record::builder()
             .level(Level::Warn)
             .target("internal_null_byte_in_message")
-            .args(format_args!("systemd_journal_logger with \x00 byte"))
+            .args(format_args!("systemd_journal_logger_memfd_syscall with \x00 byte"))
             .build(),
     );
 
@@ -73,7 +73,7 @@ fn internal_null_byte_in_message() {
     assert_eq!(entry["PRIORITY"], "4");
     assert_eq!(
         entry["MESSAGE"].as_text(),
-        "systemd_journal_logger with \x00 byte"
+        "systemd_journal_logger_memfd_syscall with \x00 byte"
     );
 }
 
@@ -84,7 +84,7 @@ fn multiline_message() {
             .level(Level::Error)
             .target("multiline_message")
             .args(format_args!(
-                "systemd_journal_logger test\nwith\nline {}",
+                "systemd_journal_logger_memfd_syscall test\nwith\nline {}",
                 "breaks"
             ))
             .build(),
@@ -94,7 +94,7 @@ fn multiline_message() {
     assert_eq!(entry["PRIORITY"], "3");
     assert_eq!(
         entry["MESSAGE"],
-        "systemd_journal_logger test\nwith\nline breaks"
+        "systemd_journal_logger_memfd_syscall test\nwith\nline breaks"
     );
 }
 

--- a/tests/log_with_extra_fields.rs
+++ b/tests/log_with_extra_fields.rs
@@ -11,7 +11,7 @@
 mod journal;
 
 use similar_asserts::assert_eq;
-use systemd_journal_logger::JournalLog;
+use systemd_journal_logger_memfd_syscall::JournalLog;
 
 #[derive(Debug)]
 struct SomeDummy {


### PR DESCRIPTION
Make the changes required to call the `memfd_syscall` instead of the libc function and rename crate to be able to publish in crates.io.