### PR TITLE
Update MSRV to 1.66.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Test against MRSV and stable
-        rust: ['1.71.0', 'stable']
+        rust: ['1.66.0', 'stable']
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ description = "Systemd journal logger for the log facade."
 categories = ["development-tools::debugging"]
 keywords = ["logging", "systemd", "journal"]
 edition = "2021"
-rust-version = "1.71"
+# When updating the rust-version, update the version of the compiler used 
+# in the pipelines under .github/workflows
+rust-version = "1.66"
 
 [dependencies]
 # libsystemd isn't no_std compatible so we can conveniently enable log's std

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Both loggers use mostly the same fields and priorities as this implementation.
 [1]: https://docs.rs/systemd/0.8.2/systemd/journal/struct.JournalLog.html
 [slog]: https://github.com/slog-rs/slog
 
+## Minimum Supported Rust Version
+
+The MSRV used in this repo is best effort only and may be bumped at any time, even in patch releases.
+
 ## License
 
 Either [MIT](./LICENSE-MIT) or [Apache 2.0](./LICENSE-APACHE-2.0), at your option.


### PR DESCRIPTION
The features used in this repo are supported from compiler 1.66.0.

Specifically the minimum version is specified from the use of `std::os::fd::AsFd;` which was introduced in rust with [commit](https://github.com/rust-lang/rust/pull/98368/commits/c846a2af8ddaa14ff2c2da25bc97bbd8d4284df2).

This is not a request for supporting this old version. It just defining better the minimum version. For the unlucky of us that are still stuck with an older version of rust, it would be nice to use this great crate, without having to integrate it locally in our project to change a single line in cargo :)


P.S.: Some background for this change -- Yocto builds with rust (using the mixin layers) are currently supporting 1.68.2. 