### PR TITLE
Add thread id into the fields logged

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ impl<'a, 'kvs> VisitSource<'kvs> for WriteKeyValues<'a> {
 ///
 /// - `TARGET`: The target of the log record (see [`log::Record::target()`]).
 /// - `CODE_MODULE`: The module path of the log record (see [`log::Record::module_path()`], only if present).
+/// - `THREAD_ID`: The current thread id in debug format [`std::thread::ThreadId`]).
 ///
 /// [journal fields]: https://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
 ///
@@ -205,6 +206,11 @@ fn record_payload(syslog_identifier: &str, record: &Record) -> Vec<u8> {
             syslog_identifier.as_bytes(),
         );
     }
+    put_field_bytes(
+        &mut buffer,
+        WellFormed("THREAD_ID"),
+        format!("{:?}", std::thread::current().id()).as_bytes(),
+    );
     if let Some(file) = record.file() {
         put_field_bytes(&mut buffer, WellFormed("CODE_FILE"), file.as_bytes());
     }

--- a/tests/log_to_journal.rs
+++ b/tests/log_to_journal.rs
@@ -53,6 +53,7 @@ fn simple_log_entry() {
             .to_str()
             .unwrap()
     );
+    assert!(entry.contains_key("THREAD_ID"));
 
     assert_eq!(entry["SYSLOG_PID"], std::process::id().to_string());
     // // The PID we logged is equal to the PID systemd determined as source for our process


### PR DESCRIPTION
This can be pretty handy for multi threaded program to follow the flow of log per thread.

It would have been better to have the u64 instead of its debug format but the api for that is not stable
https://doc.rust-lang.org/1.70.0/std/thread/struct.ThreadId.html#method.as_u64